### PR TITLE
Add dark and light modes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,8 @@ baseurl: "/BOSS22" # the subpath of your site, e.g. /blog
 url: "https://bioinformatics-hub-ke.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: BioinfoHub_KE
 github_username:  bioinformatics-hub-ke
-minimal_mistakes_skin: "neon" # "default", "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
+minimal_mistakes_skin_dark: "neon" # "default", "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
+minimal_mistakes_skin_light: "sunrise"
 
 exclude:
   - "README.md"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,24 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/dark.css' | relative_url }}" id="theme_dark">
+{% if site.minimal_mistakes_skin_light %}
+<link rel="stylesheet alternate" href="{{ '/assets/css/light.css' | relative_url }}" id="theme_light">
+<script>
+  let theme = sessionStorage.getItem('theme');
+  if (theme === "dark") {
+    sessionStorage.setItem('theme', 'dark');
+    node1 = document.getElementById('theme_dark');
+    node2 = document.getElementById('theme_light');
+    node1.setAttribute('rel', 'stylesheet alternate');
+    node2.setAttribute('rel', 'stylesheet');
+  }
+  else {
+    sessionStorage.setItem('theme', 'light');
+  }
+</script>
+
+{% endif %}
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css"></noscript>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,18 +19,17 @@
 <link rel="stylesheet alternate" href="{{ '/assets/css/light.css' | relative_url }}" id="theme_light">
 <script>
   let theme = sessionStorage.getItem('theme');
-  if (theme === "dark") {
-    sessionStorage.setItem('theme', 'dark');
+  if (theme === "light") {
+    sessionStorage.setItem('theme', 'light');
     node1 = document.getElementById('theme_dark');
     node2 = document.getElementById('theme_light');
     node1.setAttribute('rel', 'stylesheet alternate');
     node2.setAttribute('rel', 'stylesheet');
   }
   else {
-    sessionStorage.setItem('theme', 'light');
+    sessionStorage.setItem('theme', 'dark');
   }
 </script>
-
 {% endif %}
 <link rel="preload" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5/css/all.min.css"></noscript>

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,4 +1,3 @@
-<head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,11 +10,8 @@
   <link rel="shortcut icon" href="{{ "/assets/images/favicon.ico" | relative_url }}">
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="msapplication-config" content="assets/images/browserconfig.xml">
-  <meta name="theme-color" content="#ffffff">
 
-  <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}
-</head>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -18,7 +18,10 @@
             </li>
           {%- endfor -%}
         </ul>
-        {% if site.search == true %}
+        {% if site.minimal_mistakes_skin_light %}
+          <i class="fas fa-fw fa-adjust" aria-hidden="true" onclick="node1=document.getElementById('theme_dark');node2=document.getElementById('theme_light');if(node1.getAttribute('rel')=='stylesheet'){node1.setAttribute('rel', 'stylesheet alternate'); node2.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'light');}else{node2.setAttribute('rel', 'stylesheet alternate'); node1.setAttribute('rel', 'stylesheet');sessionStorage.setItem('theme', 'dark');} return false;"></i>
+        {% endif %}
+	{% if site.search == true %}
         <button class="search__toggle" type="button">
           <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>
           <i class="fas fa-search"></i>

--- a/assets/css/dark.scss
+++ b/assets/css/dark.scss
@@ -1,0 +1,8 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_dark }}"; // skin
+@import "minimal-mistakes"; // main partials

--- a/assets/css/dark.scss
+++ b/assets/css/dark.scss
@@ -4,5 +4,5 @@
 
 @charset "utf-8";
 
-@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_dark }}"; // skin
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_dark | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials

--- a/assets/css/light.scss
+++ b/assets/css/light.scss
@@ -4,5 +4,5 @@
 
 @charset "utf-8";
 
-@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_light }}"; // skin
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_light | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials

--- a/assets/css/light.scss
+++ b/assets/css/light.scss
@@ -1,0 +1,8 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
+@charset "utf-8";
+
+@import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin_light }}"; // skin
+@import "minimal-mistakes"; // main partials


### PR DESCRIPTION
Follows:
Example page https://www.vladsiv.com/
Source https://github.com/VladimirSiv/VladimirSiv.github.io
Related discussion
Allow user to toggle between themes [light/dark] mmistakes/minimal-mistakes#203

Example screenshots of light mode using the `sunrise` skin
![TopLight](https://user-images.githubusercontent.com/1679477/156918926-0c140259-b3db-4013-a3f7-f9964d08b4ab.png)
![BottomLight](https://user-images.githubusercontent.com/1679477/156918927-e0a946ae-4dce-4deb-a7f4-0487bbdb97c8.png)

Link to other default [minimal mistakes skins](https://mmistakes.github.io/minimal-mistakes/docs/configuration/#skin)