### PR TITLE
Moved abstract submission link to the top

### DIFF
--- a/pages/en/register.markdown
+++ b/pages/en/register.markdown
@@ -5,9 +5,8 @@ permalink: /register/
 lang: en
 ---
 
-## Call for Abstract Submissions:
+## [Call for Abstract Submissions](https://openreview.net/group?id=bioinformatics-hub-ke.github.io/BOSS/2022/Conference)
 
-<!--Add a call for abstract submissions-->
 We invite submissions to the BOSS conference 2022 (also known as BOSSCon 2022), which aims to empower researchers with skills in bioinformatics and open science skills. We would love to receive abstracts for contributed talks by 4th April 2022. BOSSCon 2022 covers all aspects of bioinformatics and open science, including (but not limited to) these topics:
 - Reproducible Research
 - Research Data Management
@@ -26,10 +25,9 @@ We invite submissions to the BOSS conference 2022 (also known as BOSSCon 2022), 
 - Contamination of water
 - Careers in open science
 - Alternative career paths in genomics
-- Working and studying outside Kenya
 
-### The review process
-Papers will be selected via a rigorous double-blind peer-review process on OpenReview, with submissions and reviews being private until a decision is made. Reviews and discussions of the accepted papers will be made available after acceptance. All accepted papers will be presented at the Conference as contributed talks.
+### Submission Link
+Submissions are done in Open Review. Follow this link: [Submit Abstract](https://openreview.net/group?id=bioinformatics-hub-ke.github.io/BOSS/2022/Conference)
 
 ### Key dates
 The planned dates are as follows:
@@ -38,8 +36,8 @@ The planned dates are as follows:
 - Abstract notification: 18th April 2022
 - Registration open: 10th March 2022
 
-### Submission Link
-Submissions are done in Open Review. Follow this link: [Register Here](https://openreview.net/group?id=bioinformatics-hub-ke.github.io/BOSS/2022/Conference)
-
 ### Submission Guidelines
-Visit our wiki pages for Abstract submission guidelines
+Visit our [wiki pages](https://github.com/bioinformatics-hub-ke/BOSS22/wiki/How-to-Submit-Abstract) for Abstract submission guidelines
+
+### The review process
+Papers will be selected via a rigorous double-blind peer-review process on OpenReview, with submissions and reviews being private until a decision is made. Reviews and discussions of the accepted papers will be made available after acceptance. All accepted papers will be presented at the Conference as contributed talks.


### PR DESCRIPTION
The Abstract Link was buried at the end of the page